### PR TITLE
Bump sourcetool to v0.6.1

### DIFF
--- a/.github/workflows/compute_slsa_source.yml
+++ b/.github/workflows/compute_slsa_source.yml
@@ -21,7 +21,7 @@ on:
       version:
         description: "sourcetool version to run"
         type: string
-        default: "v0.6.0"
+        default: "v0.6.1"
         required: false
 
 jobs:


### PR DESCRIPTION
Thi updates the provenance compute workflow to use sourcetool v0.6.1 by default