### PR TITLE
Verify sourcetool's attestation signer ID

### DIFF
--- a/slsa_with_provenance/action.yml
+++ b/slsa_with_provenance/action.yml
@@ -86,6 +86,7 @@ runs:
         subject: ${{ github.workspace }}/.bin/sourcetool
         collector: "jsonl:${{ github.workspace }}/.bin/sourcetool.intoto.jsonl"
         policy: "git+https://github.com/carabiner-dev/policies#slsa/builderid-base.json"
+        signer: "sigstore(regexp)::https://token.actions.githubusercontent.com::https://github.com/slsa-framework/slsa-source-poc/.github/workflows/release.yaml@.*"
     
     - id: handle_branch_push
       name: Generate attestations


### PR DESCRIPTION
This commit adds verification of the signer ID of the binary provenance build attestation.

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@carabiner.dev>