### PR TITLE
Add use_local_policy input parameters

### DIFF
--- a/slsa_with_provenance/action.yml
+++ b/slsa_with_provenance/action.yml
@@ -16,6 +16,11 @@ inputs:
     required: false
     default: false
 
+  use_local_policy:
+    description: 'Use local source policy'
+    required: false
+    default: ""
+
   version:
     description: "sourcetool version to use"
     required: true
@@ -98,6 +103,7 @@ runs:
           --commit ${{ github.sha }} --owner ${{ github.repository_owner }} \
           --repo ${{ github.event.repository.name }} --branch ${{ github.ref_name }} \
           --allow-merge-commits="${{ inputs.allow-merge-commits }}" \
+          --use_local_policy="${{ inputs.use_local_policy }}" \
           --output_signed_bundle ${{ github.workspace }}/metadata/signed_bundle.intoto.jsonl >> $GITHUB_STEP_SUMMARY
       shell: bash
       env:


### PR DESCRIPTION
I have a [demo project](https://github.com/DahuK/slsa-attestation-action-demo) that I'd like tointegrate with the SLSA Action and achieve SLSA_SOURCE_LEVEL_3. According to the [Policy](https://github.com/slsa-framework/source-tool/blob/main/docs/DESIGN.md#policy) design documentation, I understand that this mechanism is used to prevent users from disabling controls, making changes, and then re-enabling the controls. However, for certain testing and integration purposes, would it be possible to add a use_local_policy parameter to allow the pipeline to reference a local policy file from the job's environment?

