### PR TITLE
Build using latest go release

### DIFF
--- a/slsa_with_provenance/action.yml
+++ b/slsa_with_provenance/action.yml
@@ -35,17 +35,23 @@ runs:
     # This needs to persis its credentials to store the attestations
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-      if: inputs.build-from-source == 'true'
-      with:
-        go-version: '1.24' # We pin this as it is cloning two repos
-
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       id: checkout_sourcetool_code
       if: inputs.build-from-source == 'true'
       with:
         repository: slsa-framework/source-tool
         path: ${{ github.workspace }}/.bin/build
+
+    - id: go_versions
+      if: inputs.build-from-source == 'true'
+      uses: carabiner-dev/actions/go/versions@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+      with:
+        go-mod-path: ${{ github.workspace }}/.bin/build/go.mod
+
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      if: inputs.build-from-source == 'true'
+      with:
+        go-version: ${{ steps.go_versions.outputs.GO_VERSION_STABLE }}
 
     # This is building sourcetool from source. This step will be replaced
     # to run the built binary once things are stable.


### PR DESCRIPTION
This PR ensures that the action always builds the sourcetool binary with the latest go version.