### PR TITLE
Pass --push when building from source

### DIFF
--- a/slsa_with_provenance/action.yml
+++ b/slsa_with_provenance/action.yml
@@ -104,6 +104,7 @@ runs:
           --commit ${{ github.sha }} --owner ${{ github.repository_owner }} \
           --repo ${{ github.event.repository.name }} --branch ${{ github.ref_name }} \
           --allow-merge-commits="${{ inputs.allow-merge-commits }}" \
+          ${{ inputs.build-from-source == 'true' && '--push=notes' || '' }} \
           --output_signed_bundle ${{ github.workspace }}/metadata/signed_bundle.intoto.jsonl >> $GITHUB_STEP_SUMMARY
       shell: bash
       env:
@@ -114,7 +115,12 @@ runs:
       run: |
         echo "## SLSA Source Properties Tag Push" >> $GITHUB_STEP_SUMMARY
         mkdir metadata
-        ${{ github.workspace }}/.bin/sourcetool --github_token ${{ github.token }} checktag --commit ${{ github.sha }} --owner ${{ github.repository_owner }} --repo ${{ github.event.repository.name }} --tag_name ${{ github.ref_name }} --actor ${{github.triggering_actor}} --output_signed_bundle ${{ github.workspace }}/metadata/signed_bundle.intoto.jsonl >> $GITHUB_STEP_SUMMARY
+        ${{ github.workspace }}/.bin/sourcetool --github_token ${{ github.token }} checktag \
+          --commit ${{ github.sha }} --owner ${{ github.repository_owner }} \
+          --repo ${{ github.event.repository.name }} --tag_name ${{ github.ref_name }} \
+          --actor ${{github.triggering_actor}} \
+          ${{ inputs.build-from-source == 'true' && '--push=notes' || '' }} \
+          --output_signed_bundle ${{ github.workspace }}/metadata/signed_bundle.intoto.jsonl >> $GITHUB_STEP_SUMMARY
       shell: bash
       env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
When building from source, we pass --push=note to preserve the compatibility with the pre 0.7 versions of source tool for now.