### PR TITLE
Only run notes push step on legacy versions

### DIFF
--- a/slsa_with_provenance/action.yml
+++ b/slsa_with_provenance/action.yml
@@ -175,6 +175,10 @@ runs:
         cat ${{ github.workspace }}/metadata/signed_bundle.intoto.jsonl >> $GITHUB_STEP_SUMMARY
       shell: bash
 
+    # Legacy note storage: only runs when sourcetool did NOT push the note
+    # itself (i.e. when the --push=note flag was not passed). Newer sourcetool
+    # versions store the git note natively, so running this too would append a
+    # duplicate attestation to refs/notes.
     - run: |
           git config user.name "${ACTOR}"
           git config user.email "${ACTOR}@users.noreply.github.com"
@@ -183,6 +187,7 @@ runs:
           git push origin "refs/notes/*"
       shell: bash
       name: store git note
+      if: steps.configure_push.outputs.push_flag == ''
       env:
         ACTOR: ${{ github.actor }}
 


### PR DESCRIPTION
This PR modifies the provenance generator wot only run the git push step to store the attestations on older (pre 0.7) sourcetool versions to prevent storing duplicates as sourcetool now stores the notes natively.